### PR TITLE
cargo.toml: reduce release binary size by 10x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "bigarchiver"
 version = "0.1.0"
 edition = "2021"
 
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true
+
 [dependencies]
 libc = "0.2.151"
 liblzma = { version = "0.2.1", features = ["parallel", "static"] }


### PR DESCRIPTION
The new release profile options do the following:

* `strip = true` causes debug symbols to be stripped from the final
  binary
* `codegen-units = 1` reduces redundancies in codegen optimizations by
  forcing all code generation through a single unit
* `lto = true` something something link-time optimization

For me this took the binary size down from 7MB to roughly 682KB.
