### PR TITLE
should build on stable rust

### DIFF
--- a/src/comp_decomp_2.rs
+++ b/src/comp_decomp_2.rs
@@ -15,7 +15,7 @@ impl<'a, T: DataSink> Conv<'a, T> {
 
 impl<'a, T: DataSink> Write for Conv<'a, T> {
     fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
-        self.t.add(data).map(|_|data.len()).map_err(|e| std::io::Error::other(e))
+        self.t.add(data).map(|_|data.len()).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
     }
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())


### PR DESCRIPTION
This PR replaces the use of unsable feature
https://github.com/rust-lang/rust/issues/91946 with its corresponding
stable branch equivalent that is slightly more verbose.
